### PR TITLE
The best replacement for ArrayProxy is... nothing

### DIFF
--- a/app/components/todo-list.js
+++ b/app/components/todo-list.js
@@ -1,31 +1,14 @@
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
-import Redux from 'npm:redux';
-
-var { createStore } = Redux;
-
-var reducer = ((state=[], action) => {
-    if(action.type === 'ADD') {
-        return state.concat({name: 'added'});
-    }
-    return state;
-});
-
-var store = createStore(reducer);
 
 var TodoListComponent = Ember.Component.extend({
     init: function() {
         this._super(...arguments);
-        store.subscribe(() => {
-            this.notifyPropertyChange('todos');
-        });
+        this.todos = [];
     },
-    todos: Ember.computed(function() {
-        return store.getState();
-    }),
     actions: {
         add: function() {
-            store.dispatch({type: 'ADD'});
+          this.set('todos', this.get('todos').concat({ name: 'added' }));
         }
     },
     layout: hbs`

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.0",
-    "redux": "^3.3.1",
     "ember-browserify": "^1.0.2"
   }
 }


### PR DESCRIPTION
The reason Ember used to need `ArrayProxy` was that you wanted fine-grained re-rendering when only a small amount of a list changed. So you would keep the list itself as a stable value and use KVO-aware methods to mutate it.

But since Ember 1.13 introduced glimmer, none of that is necessary. You can just throw an entirely new Array at glimmer and it will still do a very efficient minimalist re-render (which can be fine-tuned when necessary by passing `keys=` to `#each`, but the default behavior is usually correct anyway).

So while it is intentional that Ember composes nicely with whatever data layer you want, and redux is a fine choice, it is absolutely not necessary to do the kind of thing you're doing in this demo.
